### PR TITLE
Adding support for Unicode characters

### DIFF
--- a/Source/Activities/CodeQuality/Sonar/Sonar.cs
+++ b/Source/Activities/CodeQuality/Sonar/Sonar.cs
@@ -193,7 +193,7 @@ namespace TfsBuildExtensions.Activities.CodeQuality
                                         templatePropertiesPath,
                                         localProjectPath);
                                     this.LogBuildMessage(properties, BuildMessageImportance.Low);
-                                    File.WriteAllText(sonarPropertiesPath, properties, Encoding.ASCII);
+                                    File.WriteAllText(sonarPropertiesPath, properties, Encoding.UTF8);
                                 }
                                 else
                                 {


### PR DESCRIPTION
Previously, the Sonar properties template file was always saved using ASCII encoding.

Fixes #7 